### PR TITLE
added formatting and corrected spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 #Pink Slipper
 
-Pink Slipper is a MarkLogic tool to execute [CoRB](https://github.com/marklogic/corb2) code enitrely within MarkLogic.  No command line.  No Java.  Simply kick your job off and wait.  Job status tracking allows you to check if your job is complete.  Pink Slipper gives you all the familiarty of CoRB with the piece of mind provided through job status.
+Pink Slipper is a MarkLogic tool to execute [CoRB](https://github.com/marklogic/corb2) code entirely within MarkLogic.  No command line.  No Java.  Simply kick your job off and wait.  Job status tracking allows you to check if your job is complete.  Pink Slipper gives you all the familiarity of CoRB with the piece of mind provided through job status.
 
 The main goals of Pink Slipper are:
 
 * CoRB compatability - Write your code just like you would for CoRB
 * Status tracking - Track your job, to confirm successful completion
-* Simplicity and ease of use - Copy a single xquery module into your project
+* Simplicity and ease of use - Copy a single XQuery module into your project
 
 How to use Pink Slipper:
 
 1. Copy src/app/lib/pink-slipper.xqy into your project
 2. Write your CoRB modules
 3. Import Pink Slipper into your module
-4. Create a map containing your CoRB properties (eg URIS-MODULE)
-5. Call ps:run()
-6. Check job status as needed with ps:get-job-status()
+4. Create a map containing your [CoRB options](https://github.com/marklogic/corb2#options) (eg URIS-MODULE)
+5. Call `ps:run()`
+6. Check job status as needed with `ps:get-job-status()`
 
 Code example to start job:
 ```XQuery

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The main goals of Pink Slipper are:
 
 How to use Pink Slipper:
 
-1. Copy src/app/lib/pink-slipper.xqy into your project
+1. Copy [src/app/lib/pink-slipper.xqy](src/app/lib/pink-slipper.xqy) into your project
 2. Write your CoRB modules
 3. Import Pink Slipper into your module
 4. Create a map containing your [CoRB options](https://github.com/marklogic/corb2#options) (eg URIS-MODULE)


### PR DESCRIPTION
- changed “CoRB properties” to “CoRB options” (consistent vocabulary),
and added a link to the options section of the CoRB2 README
- added code formatting around the methods in the how to use section
- corrected spelling of “familiarity” and “entirely”
- Changed case of XQuery